### PR TITLE
Update nomad to run k0s

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-nomad filter=lfs diff=lfs merge=lfs -text
+#nomad filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+nomad filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ hashicorp/packer/windows/ansible/connection_plugins/__pycache__**
 **.iso
 secret.sh
 token.txt
+package

--- a/hashiqube/bin/linux-amd64/nomad
+++ b/hashiqube/bin/linux-amd64/nomad
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8a927de58da16b5e36b2e972eace1e133c057f70453ee8799710ed57f836fb9
+size 102775320

--- a/hashiqube/bin/linux-arm64/nomad
+++ b/hashiqube/bin/linux-arm64/nomad
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd2afe6fb0fb32851c626a6ec5e06ca9e3c1edbf68eced6445f514861c2855f1
+size 97561200


### PR DESCRIPTION
Add Nomad configs to enable host_volume for k0s, and enable docker volumes.

Also include version of Nomad binaries so that we can run the special Nomad build that supports cgroupns. Special build version can be found [here](https://github.com/hashicorp/nomad/actions/runs/5312709136).